### PR TITLE
chore(openapi): Sync vendored openapi.yaml with schemas@97599d4

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1072,11 +1072,28 @@ components:
           description: The index of the choice in the list of choices.
         message:
           $ref: '#/components/schemas/Message'
+        logprobs:
+          description: Log probability information for the choice.
+          type: object
+          nullable: true
+          properties:
+            content:
+              description: A list of message content tokens with log probability information.
+              type: array
+              items:
+                $ref: '#/components/schemas/ChatCompletionTokenLogprob'
+            refusal:
+              description: A list of message refusal tokens with log probability information.
+              type: array
+              items:
+                $ref: '#/components/schemas/ChatCompletionTokenLogprob'
+          required:
+            - content
+            - refusal
       required:
         - finish_reason
         - index
         - message
-        - logprobs
     ChatCompletionStreamChoice:
       type: object
       required:

--- a/src/types/generated/index.ts
+++ b/src/types/generated/index.ts
@@ -411,6 +411,13 @@ export interface components {
       /** @description The index of the choice in the list of choices. */
       index: number;
       message: components['schemas']['Message'];
+      /** @description Log probability information for the choice. */
+      logprobs?: {
+        /** @description A list of message content tokens with log probability information. */
+        content: components['schemas']['ChatCompletionTokenLogprob'][];
+        /** @description A list of message refusal tokens with log probability information. */
+        refusal: components['schemas']['ChatCompletionTokenLogprob'][];
+      } | null;
     };
     ChatCompletionStreamChoice: {
       delta: components['schemas']['ChatCompletionStreamResponseDelta'];


### PR DESCRIPTION
## Summary

Refresh the vendored `openapi.yaml` from `inference-gateway/schemas` at SHA `97599d4a90188fc73bb41be1d580993415ffe06f` and regenerate `src/types/generated/index.ts` so the SDK matches the canonical schema.

- `ChatCompletionChoice.logprobs` is now a structured nullable object (`{ content: ChatCompletionTokenLogprob[], refusal: ChatCompletionTokenLogprob[] } | null`) and is no longer required.
- Confirmed no consumers in `src/`, `tests/`, or `examples/` rely on `logprobs` being present on every choice.

## Validation

- `npm run lint` — clean
- `npm run build` — clean
- `npm test` — 21/21 passing

Closes #24

Generated with [Claude Code](https://claude.ai/code)